### PR TITLE
Simplify return case handling in `handle_events_of_with_callback`

### DIFF
--- a/crates/nostr-sdk/src/lib.rs
+++ b/crates/nostr-sdk/src/lib.rs
@@ -29,7 +29,7 @@ pub mod relay;
 #[cfg(feature = "blocking")]
 pub use self::client::blocking;
 pub use self::client::{Client, Options};
-pub use self::relay::{Relay, RelayOptions, RelayPoolNotification, RelayStatus};
+pub use self::relay::{FilterOptions, Relay, RelayOptions, RelayPoolNotification, RelayStatus};
 
 #[cfg(feature = "blocking")]
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("Can't start Tokio runtime"));

--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -757,8 +757,14 @@ impl Relay {
         let mut counter = 0;
         let mut received_eose: bool = false;
 
+        let (tx_eose_timeout, mut rx_eose_timeout) = broadcast::channel::<()>(1);
+        let (tx_got_eose, mut rx_got_eose) = broadcast::channel::<()>(1);
+        let (tx_wait_duration, mut rx_wait_duration) = broadcast::channel::<()>(1);
+        let (tx_wait_num, mut rx_wait_num) = broadcast::channel::<()>(1);
+
         let mut notifications = self.notification_sender.subscribe();
-        time::timeout(timeout, async {
+        let tx_got_eose_clone = tx_got_eose.clone();
+        let receive_and_handle_notifications = || async move {
             while let Ok(notification) = notifications.recv().await {
                 if let RelayPoolNotification::Message(_, msg) = notification {
                     match msg {
@@ -772,7 +778,7 @@ impl Relay {
                                     if received_eose {
                                         counter += 1;
                                         if counter >= num {
-                                            break;
+                                            tx_wait_num.send(()).expect(""); // TODO TBD err mgmt
                                         }
                                     }
                                 }
@@ -781,40 +787,42 @@ impl Relay {
                         RelayMessage::EndOfStoredEvents(subscription_id) => {
                             if subscription_id.eq(&id) {
                                 received_eose = true;
-                                if let FilterOptions::ExitOnEOSE
-                                | FilterOptions::WaitDurationAfterEOSE(_) = opts
-                                {
-                                    break;
+                                let _ = tx_got_eose_clone.send(()); // TODO TBD err mgmt
+
+                                if let FilterOptions::WaitDurationAfterEOSE(duration) = opts {
+                                    let tx_wait_duration_clone = tx_wait_duration.clone();
+                                    thread::spawn(async move {
+                                        thread::sleep(duration).await;
+                                        let _ = tx_wait_duration_clone.send(());
+                                    });
                                 }
                             }
                         }
-                        _ => log::debug!("Receive unhandled message {msg:?} on handle_events_of"),
+                        _ => log::debug!("Receive unhandled message {msg:?} on get_events_of"),
                     };
                 }
             }
+        };
 
-            if let FilterOptions::WaitDurationAfterEOSE(duration) = opts {
-                time::timeout(Some(duration), async {
-                    while let Ok(notification) = notifications.recv().await {
-                        if let RelayPoolNotification::Message(
-                            _,
-                            RelayMessage::Event {
-                                subscription_id,
-                                event,
-                            },
-                        ) = notification
-                        {
-                            if subscription_id.eq(&id) {
-                                callback(*event).await;
-                            }
-                        }
-                    }
-                })
-                .await;
+        // Use a clone of tx_eose_timeout, such that the original tx_eose_timeout remains in scope
+        // If it's not in scope, and the EOSE is received immediately (before the select! block below),
+        // then the rx_eose_timeout branch will return first with a Closed error, because the corresponding
+        // tx_eose_timeout had already been dropped, so rx_eose_timeout.recv() cannot receive
+        let tx_eose_timeout_clone = tx_eose_timeout.clone();
+        thread::spawn(async move {
+            let mut rx1 = tx_got_eose.subscribe();
+            if time::timeout(timeout, rx1.recv()).await.is_none() {
+                tx_eose_timeout_clone.send(()).expect(""); // TODO TBD err mgmt
             }
-        })
-        .await
-        .ok_or(Error::Timeout)
+        });
+
+        tokio::select! {
+            _ = receive_and_handle_notifications() => Err(Error::RecvTimeout), // TODO correct err type?
+            _ = rx_eose_timeout.recv() => Err(Error::Timeout),
+            _ = rx_got_eose.recv(), if matches!(opts, FilterOptions::ExitOnEOSE) => Ok(()),
+            _ = rx_wait_duration.recv(), if matches!(opts, FilterOptions::WaitDurationAfterEOSE(_)) => Ok(()),
+            _ = rx_wait_num.recv(), if matches!(opts, FilterOptions::WaitForEventsAfterEOSE(_)) => Ok(())
+        }
     }
 
     /// Get events of filters with custom callback

--- a/crates/nostr-sdk/src/relay/options.rs
+++ b/crates/nostr-sdk/src/relay/options.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Distributed under the MIT software license
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// [`Relay`] options
+#[derive(Debug, Clone)]
+pub struct RelayOptions {
+    /// Allow/disallow read actions
+    read: Arc<AtomicBool>,
+    /// Allow/disallow write actions
+    write: Arc<AtomicBool>,
+}
+
+impl Default for RelayOptions {
+    fn default() -> Self {
+        Self::new(true, true)
+    }
+}
+
+impl RelayOptions {
+    /// New [`RelayOptions`]
+    pub fn new(read: bool, write: bool) -> Self {
+        Self {
+            read: Arc::new(AtomicBool::new(read)),
+            write: Arc::new(AtomicBool::new(write)),
+        }
+    }
+
+    /// Get read option
+    pub fn read(&self) -> bool {
+        self.read.load(Ordering::SeqCst)
+    }
+
+    /// Set read option
+    pub fn set_read(&self, read: bool) {
+        let _ = self
+            .read
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| Some(read));
+    }
+
+    /// Get write option
+    pub fn write(&self) -> bool {
+        self.write.load(Ordering::SeqCst)
+    }
+
+    /// Set write option
+    pub fn set_write(&self, write: bool) {
+        let _ = self
+            .write
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| Some(write));
+    }
+}
+
+/// Filter options
+#[derive(Debug, Clone, Copy, Default)]
+pub enum FilterOptions {
+    /// Exit on EOSE
+    #[default]
+    ExitOnEOSE,
+    /// After EOSE is received, keep listening for N more events that match the filter, then return
+    WaitForEventsAfterEOSE(u16),
+    /// After EOSE is received, keep listening for matching events for [`Duration`] more time, then return
+    WaitDurationAfterEOSE(Duration),
+}


### PR DESCRIPTION
Attempt to simplify the different exit conditions from `handle_events_of_with_callback`.

Tested all 3 variants.